### PR TITLE
Caching

### DIFF
--- a/pims/__init__.py
+++ b/pims/__init__.py
@@ -18,9 +18,4 @@ from .__version__ import __version__, __api_version__
 from .__version__ import __license__, __copyright__
 from .__version__ import __author__, __email__
 
-# PIMS constants
-PIMS_SLUG_JPEG = "JPEG"
-PIMS_SLUG_WEBP = "WEBP"
-PIMS_SLUG_PNG = "PNG"
-
 UNIT_REGISTRY = pint.UnitRegistry()

--- a/pims/api/utils/header.py
+++ b/pims/api/utils/header.py
@@ -138,6 +138,9 @@ class ImageRequestHeaders:
         self.accept = accept
         self.safe_mode = safe_mode
 
+    def get(self, header, default=None):
+        return getattr(self, header, default)
+
 
 class ImageAnnotationRequestHeaders(ImageRequestHeaders):
     def __init__(

--- a/pims/api/utils/mimetype.py
+++ b/pims/api/utils/mimetype.py
@@ -16,20 +16,33 @@ from collections import OrderedDict
 from enum import Enum
 from functools import cached_property
 
-from pims import PIMS_SLUG_PNG, PIMS_SLUG_WEBP, PIMS_SLUG_JPEG
 from pims.api.exceptions import NoAcceptableResponseMimetypeProblem
 from fastapi.params import Path as PathParam
 
+
+class OutputExtension(str, Enum):
+    NONE = ""
+    JPEG = ".jpg"
+    PNG = ".png"
+    WEBP = ".webp"
+
+
+mimetype_from_extension = {
+    OutputExtension.JPEG: "image/jpeg",
+    OutputExtension.PNG: "image/png",
+    OutputExtension.WEBP: "image/webp"
+}
+
 PNG_MIMETYPES = {
-    "image/png": PIMS_SLUG_PNG,
-    "image/apng":  PIMS_SLUG_PNG
+    "image/png": OutputExtension.PNG,
+    "image/apng":  OutputExtension.PNG
 }
 WEBP_MIMETYPES = {
-    "image/webp": PIMS_SLUG_WEBP
+    "image/webp": OutputExtension.WEBP
 }
 JPEG_MIMETYPES = {
-    "image/jpg": PIMS_SLUG_JPEG,
-    "image/jpeg": PIMS_SLUG_JPEG
+    "image/jpg": OutputExtension.JPEG,
+    "image/jpeg": OutputExtension.JPEG
 }
 
 
@@ -172,20 +185,6 @@ def get_output_format(extension, accept_header, supported):
         return output_format, response_mimetype
 
     raise NoAcceptableResponseMimetypeProblem(str(), list(supported.keys()))
-
-
-class OutputExtension(str, Enum):
-    NONE = ""
-    JPEG = ".jpg"
-    PNG = ".png"
-    WEBP = ".webp"
-
-
-mimetype_from_extension = {
-    OutputExtension.JPEG: "image/jpeg",
-    OutputExtension.PNG: "image/png",
-    OutputExtension.WEBP: "image/webp"
-}
 
 
 def extension_path_parameter(

--- a/pims/application.py
+++ b/pims/application.py
@@ -20,15 +20,18 @@ from .fastapi_tweaks import apply_fastapi_tweaks
 apply_fastapi_tweaks()
 
 import time
+import aioredis
 from fastapi import FastAPI, Request
 from pydantic import ValidationError
+from fastapi_cache import FastAPICache
 
+from .cache import get_cache, RedisBackend, all_kwargs_key_builder
 from pims.config import get_settings
 from pims.docs import get_redoc_html
 from .api.exceptions import add_problem_exception_handler
 from .api import server, housekeeping, formats, metadata, thumb, window, resized, annotation, tile, operations, \
     histograms, filters, colormaps
-from . import __api_version__
+from . import __api_version__,  __version__
 
 
 app = FastAPI(
@@ -43,6 +46,23 @@ app = FastAPI(
 )
 
 
+async def _startup_cache():
+    redis = aioredis.from_url(
+        get_settings().cache_url,
+    )
+    FastAPICache.init(
+        RedisBackend(redis), prefix="pims-cache",
+        key_builder=all_kwargs_key_builder
+    )
+
+    # Flush the cache if persistent and PIMS version has changed.
+    cache = get_cache()
+    cached_version = await cache.get("PIMS_VERSION")
+    if cached_version != __version__:
+        await cache.clear(FastAPICache.get_prefix())
+        await cache.set("PIMS_VERSION", __version__)
+
+
 @app.on_event("startup")
 async def startup():
     # Check PIMS configuration
@@ -54,6 +74,7 @@ async def startup():
     except ValidationError as e:
         logger.error("Impossible to read or parse some PIMS settings:")
         logger.error(e)
+        exit(-1)
 
     # Check optimisation are enabled for external libs
     from pydantic import compiled as pydantic_compiled
@@ -67,6 +88,10 @@ async def startup():
     from shapely.speedups import enabled as shapely_speedups
     if not shapely_speedups:
         logger.warning("[red]Shapely is running without speedups.")
+
+    # Caching
+    await _startup_cache()
+    logger.info(f"[green]Cache is ready!")
 
 
 @app.middleware("http")

--- a/pims/cache.py
+++ b/pims/cache.py
@@ -140,6 +140,13 @@ def _image_response_key_builder(
 
 
 def default_cache_control_builder(ttl=0):
+    """
+    Cache-Control header is not intuitive.
+    * https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control
+    * https://web.dev/http-cache/#flowchart
+    * https://jakearchibald.com/2016/caching-best-practices/
+    * https://www.azion.com/en/blog/what-is-http-caching-and-how-does-it-work/
+    """
     params = ["private", "must-revalidate"]
     if ttl:
         params += [f"max-age={ttl}"]

--- a/pims/cache.py
+++ b/pims/cache.py
@@ -1,0 +1,168 @@
+# * Copyright (c) 2020. Authors: see NOTICE file.
+# *
+# * Licensed under the Apache License, Version 2.0 (the "License");
+# * you may not use this file except in compliance with the License.
+# * You may obtain a copy of the License at
+# *
+# *      http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * Unless required by applicable law or agreed to in writing, software
+# * distributed under the License is distributed on an "AS IS" BASIS,
+# * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# * See the License for the specific language governing permissions and
+# * limitations under the License.
+import asyncio
+import hashlib
+import inspect
+import typing
+from enum import Enum
+from functools import wraps
+from typing import Type, Callable, Optional
+
+from fastapi_cache import FastAPICache, Coder
+from fastapi_cache.backends import Backend
+from fastapi_cache.backends.redis import RedisBackend as RedisBackend_
+from fastapi_cache.coder import PickleCoder
+from starlette.concurrency import run_in_threadpool
+from starlette.responses import Response
+
+HEADER_CACHE_CONTROL = "Cache-Control"
+HEADER_ETAG = "ETag"
+HEADER_IF_NONE_MATCH = "If-None-Match"
+
+
+def get_cache() -> Backend:
+    return FastAPICache.get_backend()
+
+
+class RedisBackend(RedisBackend_):
+    async def exists(self, key) -> bool:
+        return await self.redis.exists(key)
+
+
+async def exec_func_async(func, *args, **kwargs):
+    is_async = asyncio.iscoroutinefunction(func)
+    if is_async:
+        return await func(*args, **kwargs)
+    else:
+        return await run_in_threadpool(func, *args, **kwargs)
+
+
+def all_kwargs_key_builder(func, kwargs, excluded_parameters, prefix):
+    copy_kwargs = kwargs.copy()
+    for excluded in excluded_parameters:
+        if excluded in copy_kwargs:
+            copy_kwargs.pop(excluded)
+
+    hashable = f"{func.__module__}:{func.__name__}"
+    for k, v in copy_kwargs.items():
+        if isinstance(v, Enum):
+            v = v.value
+        hashable += f":{k}={str(v)}"
+
+    hashed = hashlib.md5(hashable.encode()).hexdigest()
+    cache_key = f"{prefix}:{hashed}"
+    return cache_key
+
+
+def default_cache_control_builder(ttl=0):
+    params = ["private", "must-revalidate"]
+    if ttl:
+        params += [f"max-age={ttl}"]
+    return ','.join(params)
+
+
+def cache(
+        expire: int = None,
+        vary: Optional[typing.List] = None,
+        codec: Type[Coder] = None,
+        key_builder: Callable = None,
+        cache_control_builder: Callable = None
+):
+    def wrapper(func: Callable):
+        @wraps(func)
+        async def inner(*args, **kwargs):
+            nonlocal expire
+            nonlocal vary
+            nonlocal codec
+            nonlocal key_builder
+            nonlocal cache_control_builder
+            signature = inspect.signature(func)
+            bound_args = signature.bind_partial(*args, **kwargs)
+            bound_args.apply_defaults()
+            all_kwargs = bound_args.arguments
+            request = all_kwargs.pop("request", None)
+            response = all_kwargs.pop("response", None)
+
+            if request \
+                    and request.headers.get(HEADER_CACHE_CONTROL) == "no-store":
+                return exec_func_async(func, *args, **kwargs)
+
+            expire = expire or FastAPICache.get_expire()
+            codec = codec or FastAPICache.get_coder()
+            key_builder = key_builder or FastAPICache.get_key_builder()
+            backend = FastAPICache.get_backend()
+            prefix = FastAPICache.get_prefix()
+
+            cache_key = key_builder(func, all_kwargs, vary, prefix)
+            ttl, data = await backend.get_with_ttl(cache_key)
+            if not request:
+                if data is not None:
+                    return codec.decode(data)
+                data = await exec_func_async(func, *args, **kwargs)
+                await backend.set(
+                    cache_key, codec.encode(data),
+                    expire or FastAPICache.get_expire()
+                )
+                return data
+
+            if_none_match = request.headers.get(HEADER_IF_NONE_MATCH.lower())
+            if data is not None:
+                if response:
+                    cache_control_builder = \
+                        cache_control_builder or default_cache_control_builder
+                    response.headers[HEADER_CACHE_CONTROL] = \
+                        cache_control_builder(ttl=ttl)
+                    etag = f"W/{hash(data)}"
+                    if if_none_match == etag:
+                        response.status_code = 304
+                        return response
+                    response.headers[HEADER_ETAG] = etag
+                decoded = codec.decode(data)
+                if isinstance(decoded, Response):
+                    decoded.headers[HEADER_CACHE_CONTROL] = \
+                        response.headers.get(HEADER_CACHE_CONTROL)
+                    decoded.headers[HEADER_ETAG] = \
+                        response.headers.get(HEADER_ETAG)
+                return decoded
+
+            data = await exec_func_async(func, *args, **kwargs)
+
+            await backend.set(cache_key, codec.encode(data), expire)
+
+            if response:
+                cache_control_builder = \
+                    cache_control_builder or default_cache_control_builder
+                response.headers[HEADER_CACHE_CONTROL] = \
+                    cache_control_builder(ttl=expire)
+                etag = f"W/{hash(data)}"
+                response.headers[HEADER_ETAG] = etag
+                if isinstance(data, Response):
+                    data.headers[HEADER_CACHE_CONTROL] = \
+                        response.headers.get(HEADER_CACHE_CONTROL)
+                    data.headers[HEADER_ETAG] = \
+                        response.headers.get(HEADER_ETAG)
+
+            return data
+
+        return inner
+
+    return wrapper
+
+
+def cache_image_response(
+        expire: int = None,
+        vary: Optional[typing.List] = None,
+):
+    codec = PickleCoder
+    return cache(expire, vary, codec)

--- a/pims/config.py
+++ b/pims/config.py
@@ -1,6 +1,19 @@
-import os
-import logging
+#  * Copyright (c) 2019-2021. Authors: see NOTICE file.
+#  *
+#  * Licensed under the Apache License, Version 2.0 (the "License");
+#  * you may not use this file except in compliance with the License.
+#  * You may obtain a copy of the License at
+#  *
+#  *      http://www.apache.org/licenses/LICENSE-2.0
+#  *
+#  * Unless required by applicable law or agreed to in writing, software
+#  * distributed under the License is distributed on an "AS IS" BASIS,
+#  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  * See the License for the specific language governing permissions and
+#  * limitations under the License.
 
+import logging
+import os
 from functools import lru_cache
 
 from pydantic import BaseSettings
@@ -16,6 +29,7 @@ class Settings(BaseSettings):
     output_size_limit: int = 10000
     pims_url: str = "http://localhost-ims"
 
+    cache_enabled: bool = True
     cache_url: str = "http://pims-cache:6379"
     cache_ttl_thumb: int = 60 * 60 * 24 * 15
     cache_ttl_resized: int = 60 * 60 * 24 * 15

--- a/pims/config.py
+++ b/pims/config.py
@@ -15,7 +15,9 @@ class Settings(BaseSettings):
     default_annotation_origin: str = "LEFT_TOP"
     output_size_limit: int = 10000
     pims_url: str = "http://localhost-ims"
+
     cache_url: str = "http://pims-cache:6379"
+    cache_ttl_thumb: int = 60 * 60 * 24 * 15
 
     cytomine_public_key: str
     cytomine_private_key: str

--- a/pims/config.py
+++ b/pims/config.py
@@ -15,6 +15,7 @@ class Settings(BaseSettings):
     default_annotation_origin: str = "LEFT_TOP"
     output_size_limit: int = 10000
     pims_url: str = "http://localhost-ims"
+    cache_url: str = "http://pims-cache:6379"
 
     cytomine_public_key: str
     cytomine_private_key: str

--- a/pims/config.py
+++ b/pims/config.py
@@ -18,6 +18,9 @@ class Settings(BaseSettings):
 
     cache_url: str = "http://pims-cache:6379"
     cache_ttl_thumb: int = 60 * 60 * 24 * 15
+    cache_ttl_resized: int = 60 * 60 * 24 * 15
+    cache_ttl_tile: int = 60 * 60 * 24
+    cache_ttl_window: int = 60 * 60 * 24
 
     cytomine_public_key: str
     cytomine_private_key: str

--- a/pims/processing/image_response.py
+++ b/pims/processing/image_response.py
@@ -16,7 +16,7 @@ from functools import lru_cache
 import numpy as np
 from starlette.responses import Response
 
-from pims import PIMS_SLUG_PNG
+from pims.api.utils.mimetype import OutputExtension
 from pims.api.utils.models import Colorspace, AnnotationStyleMode, AssociatedName
 from pims.formats.utils.vips import np_dtype
 from pims.processing.colormaps import combine_lut, is_rgb_colormapping, default_lut
@@ -41,7 +41,7 @@ class View:
 
     @property
     def best_effort_bitdepth(self):
-        if self.out_format == PIMS_SLUG_PNG:
+        if self.out_format == OutputExtension.PNG:
             return min(self.out_bitdepth, 16)
         return min(self.out_bitdepth, 8)
 

--- a/pims/processing/operations.py
+++ b/pims/processing/operations.py
@@ -20,8 +20,9 @@ from pyvips import Image as VIPSImage, Size as VIPSSize
 from rasterio.features import rasterize
 from shapely.affinity import affine_transform
 
+from pims.api.utils.mimetype import OutputExtension
 from pims.api.utils.models import Colorspace
-from pims.formats.utils.vips import format_to_vips_suffix, dtype_to_vips_format, vips_format_to_dtype
+from pims.formats.utils.vips import dtype_to_vips_format, vips_format_to_dtype
 from pims.processing.adapters import imglib_adapters, numpy_to_vips
 from pims.processing.annotations import ParsedAnnotations, contour, stretch_contour
 from pims.processing.color import np_int2rgb
@@ -85,15 +86,15 @@ class OutputProcessor(ImageOp):
             return 'uint8'
 
     def _vips_impl(self, img, *args, **kwargs):
-        suffix = format_to_vips_suffix[self.format]
+        suffix = self.format
         params = self.format_params
         clean_params = {}
-        if suffix == '.jpg':
+        if suffix == OutputExtension.JPEG:
             clean_params['Q'] = params.get('quality', params.get('jpeg_quality', 75))
             clean_params['strip'] = True
-        elif suffix == '.png':
+        elif suffix == OutputExtension.PNG:
             clean_params['compression'] = params.get('compression', params.get('png_compression', 6))
-        elif suffix == '.webp':
+        elif suffix == OutputExtension.WEBP:
             clean_params['lossless'] = params.get('lossless', params.get('webp_lossless', False))
             clean_params['strip'] = True
             clean_params['Q'] = params.get('quality', params.get('webp_quality', 75))

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,10 +10,16 @@ affine==2.3.0
     # via rasterio
 aiofiles==0.7.0
     # via pims (setup.py)
+aioredis==2.0.0
+    # via
+    #   fastapi-cache2
+    #   pims (setup.py)
 asciitree==0.3.3
     # via zarr
 asgiref==3.3.4
     # via uvicorn
+async-timeout==3.0.1
+    # via aioredis
 attrs==21.2.0
     # via rasterio
 cachecontrol==0.12.6
@@ -47,6 +53,10 @@ cytomine-python-client==2.8.3
 decorator==4.4.2
     # via networkx
 fastapi==0.65.2
+    # via
+    #   fastapi-cache2
+    #   pims (setup.py)
+fastapi-cache2[redis]==0.1.6
     # via pims (setup.py)
 fasteners==0.16.3
     # via zarr
@@ -123,7 +133,9 @@ pyparsing==2.4.7
     #   packaging
     #   snuggs
 python-dateutil==2.8.1
-    # via matplotlib
+    # via
+    #   fastapi-cache2
+    #   matplotlib
 python-dotenv==0.17.1
     # via
     #   pims (setup.py)
@@ -157,7 +169,6 @@ shapely==1.8a1
     #   pims (setup.py)
 six==1.16.0
     # via
-    #   cycler
     #   cytomine-python-client
     #   fasteners
     #   python-dateutil
@@ -171,13 +182,17 @@ tifffile==2021.6.6
     #   pims (setup.py)
     #   scikit-image
 typing-extensions==3.10.0.0
-    # via pydantic
+    # via
+    #   aioredis
+    #   pydantic
 urllib3==1.26.5
     # via
     #   cytomine-python-client
     #   requests
 uvicorn[standard]==0.14.0
-    # via pims (setup.py)
+    # via
+    #   fastapi-cache2
+    #   pims (setup.py)
 uvloop==0.15.2
     # via uvicorn
 watchgod==0.7

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ REQUIRED = [
     'pathvalidate>=2.4.1',
     'importlib_metadata>=4.7.1',
     'aiofiles>=0.7.0',
+    'fastapi-cache2[redis]>=0.1.6',
 
     'Pint>=0.17',
     'palettable>=3.3.0',

--- a/setup.py
+++ b/setup.py
@@ -1,19 +1,19 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# * Copyright (c) 2020. Authors: see NOTICE file.
-# *
-# * Licensed under the Apache License, Version 2.0 (the "License");
-# * you may not use this file except in compliance with the License.
-# * You may obtain a copy of the License at
-# *
-# *      http://www.apache.org/licenses/LICENSE-2.0
-# *
-# * Unless required by applicable law or agreed to in writing, software
-# * distributed under the License is distributed on an "AS IS" BASIS,
-# * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# * See the License for the specific language governing permissions and
-# * limitations under the License.
+#  * Copyright (c) 2019-2021. Authors: see NOTICE file.
+#  *
+#  * Licensed under the Apache License, Version 2.0 (the "License");
+#  * you may not use this file except in compliance with the License.
+#  * You may obtain a copy of the License at
+#  *
+#  *      http://www.apache.org/licenses/LICENSE-2.0
+#  *
+#  * Unless required by applicable law or agreed to in writing, software
+#  * distributed under the License is distributed on an "AS IS" BASIS,
+#  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  * See the License for the specific language governing permissions and
+#  * limitations under the License.
 
 
 # See: https://github.com/navdeep-G/setup.py
@@ -26,7 +26,7 @@ import os
 import sys
 from shutil import rmtree
 
-from setuptools import find_packages, setup, Command
+from setuptools import Command, find_packages, setup
 
 # Package meta-data.
 NAME = 'pims'
@@ -44,6 +44,7 @@ REQUIRED = [
     'importlib_metadata>=4.7.1',
     'aiofiles>=0.7.0',
     'fastapi-cache2[redis]>=0.1.6',
+    'aioredis>=2.0.0',
 
     'Pint>=0.17',
     'palettable>=3.3.0',


### PR DESCRIPTION
Partially implement 1. & 2. from #8.

Image responses are stored in an in-memory DB (Redis). This cache can be long-time as for a given set of parameters, the response is only dependent from the image on disk and the version of PIMS.

Image responses are cached with a key which is a hash of the function name together with an ordered set of the parameters. As key is computed from the just FastAPI-validated input parameters, some set of parameters producing same results are cached several times. For example, asking all channels in a 3-channel image with `channels=0,1,2` or by omitting the `channels` parameter produces the same result while cached twice.

HTTP responses from (just-)cached content have a `Cache-Control` and a `Etag` header. The `Etag` is a weak hash of the response. If client send a request with a `If-None-Match` and it matches the hash of the response in the cache, a HTTP status 304 is returned.