### PR TITLE
Support basic DICOM format

### DIFF
--- a/pims/api/metadata.py
+++ b/pims/api/metadata.py
@@ -764,6 +764,77 @@ def show_metadata(
     return response_list([Metadata.from_metadata(md) for md in store.values()])
 
 
+# ANNOTATIONS
+
+class MetadataAnnotation(BaseModel):
+    """
+    A metadata annotation is an annotation stored in an image file.
+
+    """
+    geometry: str = Field(
+        ...,
+        description='A geometry described in Well-known text (WKT)',
+        example='POINT(10 10)',
+    )
+    terms: List[str] = Field(
+        ...,
+        description='A list of terms (labels) associated to the annotation',
+        example='ROI'
+    )
+    properties: dict = Field(
+        ...,
+        description='A set of key-value pairs associated to the annotation'
+    )
+    channels: List[int] = Field(
+        ...,
+        description='Channel indexes associated to the annotation'
+    )
+    z_slices: List[int] = Field(
+        ...,
+        description='Z-slice indexes associated to the annotation'
+    )
+    timepoints: List[int] = Field(
+        ...,
+        description='Timepoint indexes associated to the annotation'
+    )
+
+    @classmethod
+    def from_metadata_annotation(cls, annot):
+        return cls(
+            **{
+                "geometry": annot.wkt,
+                "terms": annot.terms,
+                "properties": annot.properties,
+                "channels": annot.channels,
+                "z_slices": annot.z_slices,
+                "timepoints": annot.timepoints
+            }
+        )
+
+
+class MetadataAnnotationCollection(CollectionSize):
+    items: List[MetadataAnnotation]
+
+
+@router.get(
+    '/image/{filepath:path}/metadata/annotations',
+    response_model=MetadataAnnotationCollection,
+    tags=api_tags
+)
+def show_metadata_annotations(
+    path: Path = Depends(imagepath_parameter)
+):
+    """
+    Get image annotation metadata
+    """
+    original = path.get_original()
+    check_representation_existence(original)
+    return response_list(
+        [MetadataAnnotation.from_metadata_annotation(a)
+         for a in original.annotations]
+    )
+
+
 # REPRESENTATIONS
 
 class RepresentationInfoCollection(CollectionSize):

--- a/pims/files/histogram.py
+++ b/pims/files/histogram.py
@@ -194,6 +194,7 @@ def _extract_np_thumb(image):
                 c = c_range[0]  # TODO
                 thumb = image.thumbnail(tw, th, precomputed=False, c=c, t=t, z=z)
                 npthumb = imglib_adapters.get((type(thumb), np.ndarray))(thumb)
+                npthumb = np.atleast_3d(npthumb)
                 if npthumb.shape[2] != len(c_range):
                     # TODO: improve palette support! !! if we get more channels than expected,
                     #  we have a color palette image For now, try to discard the palette by only

--- a/pims/files/image.py
+++ b/pims/files/image.py
@@ -151,6 +151,10 @@ class Image(Path):
     def pyramid(self):
         return self._format.pyramid
 
+    @property
+    def annotations(self):
+        return self._format.annotations
+
     @cached_property
     def normalized_pyramid(self):
         return normalized_pyramid(self.width, self.height)

--- a/pims/formats/common/dicom.py
+++ b/pims/formats/common/dicom.py
@@ -1,0 +1,155 @@
+#  * Copyright (c) 2020-2021. Authors: see NOTICE file.
+#  *
+#  * Licensed under the Apache License, Version 2.0 (the "License");
+#  * you may not use this file except in compliance with the License.
+#  * You may obtain a copy of the License at
+#  *
+#  *      http://www.apache.org/licenses/LICENSE-2.0
+#  *
+#  * Unless required by applicable law or agreed to in writing, software
+#  * distributed under the License is distributed on an "AS IS" BASIS,
+#  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  * See the License for the specific language governing permissions and
+#  * limitations under the License.
+import logging
+from datetime import datetime
+from functools import cached_property
+
+from pims import UNIT_REGISTRY
+from pims.formats.utils.abstract import AbstractFormat, AbstractParser, AbstractReader
+from pims.formats.utils.checker import SignatureChecker
+from pims.formats.utils.engines.vips import VipsHistogramReader, VipsSpatialConvertor
+from pims.formats.utils.metadata import ImageChannel, ImageMetadata, parse_float
+from pims.formats.utils.vips import np_dtype
+from pydicom import dcmread
+
+log = logging.getLogger("pims.formats")
+
+
+def cached_dcmread(format):
+    return format.get_cached('_dcmread', dcmread, format.path.resolve(), force=True)
+
+
+class DicomChecker(SignatureChecker):
+    OFFSET = 128
+
+    @classmethod
+    def match(cls, pathlike):
+        buf = cls.get_signature(pathlike)
+        return (len(buf) > cls.OFFSET + 4 and
+                buf[cls.OFFSET] == 0x44 and
+                buf[cls.OFFSET + 1] == 0x49 and
+                buf[cls.OFFSET + 2] == 0x43 and
+                buf[cls.OFFSET + 3] == 0x4D)
+
+
+class DicomParser(AbstractParser):
+    def parse_main_metadata(self):
+        ds = cached_dcmread(self.format)
+
+        imd = ImageMetadata()
+        imd.width = ds.Columns
+        imd.height = ds.Rows
+        imd.depth = 1  # TODO
+        imd.duration = 1  # TODO
+
+        imd.n_channels = ds.SamplesPerPixel  # Only 1 or 3
+        imd.n_intrinsic_channels = ds.SamplesPerPixel
+        imd.n_channels_per_read = 1
+        if imd.n_channels == 3:
+            imd.set_channel(ImageChannel(index=0, suggested_name='R'))
+            imd.set_channel(ImageChannel(index=1, suggested_name='G'))
+            imd.set_channel(ImageChannel(index=2, suggested_name='B'))
+        else:
+            imd.set_channel(ImageChannel(index=0, suggested_name='L'))
+
+        imd.significant_bits = ds.BitsAllocated
+        imd.pixel_type = np_dtype(imd.significant_bits)
+        return imd
+
+    def parse_known_metadata(self):
+        ds = cached_dcmread(self.format)
+        imd = super().parse_known_metadata()
+
+        imd.description = None  # TODO
+        imd.acquisition_datetime = self.parse_acquisition_date(
+            ds.get('AcquisitionDate'), ds.get('AcquisitionTime'))
+        if imd.acquisition_datetime is None:
+            imd.acquisition_datetime = self.parse_acquisition_date(
+                ds.get('ContentDate'), ds.get('ContentTime')
+            )
+        pixel_spacing = ds.get('PixelSpacing')
+        if pixel_spacing:
+            imd.physical_size_x = self.parse_physical_size(pixel_spacing[0])
+            imd.physical_size_y = self.parse_physical_size(pixel_spacing[1])
+        imd.physical_size_z = self.parse_physical_size(ds.get('SpacingBetweenSlices'))
+
+        imd.is_complete = True
+        return imd
+
+    @staticmethod
+    def parse_acquisition_date(date, time=None):
+        """
+        Date examples: 20211105
+        Time examples: 151034, 151034.123
+        """
+        try:
+            if date and time:
+                return datetime.strptime(f"{date} {time.split('.')[0]}", "%Y%m%d %H%M%S")
+            elif date:
+                return datetime.strptime(date, "%Y%m%d")
+            else:
+                return None
+        except (ValueError, TypeError):
+            return None
+
+    def parse_raw_metadata(self):
+        # TODO
+        return super(DicomParser, self).parse_raw_metadata()
+
+    @staticmethod
+    def parse_physical_size(physical_size):
+        if physical_size is not None and parse_float(physical_size) is not None:
+            return parse_float(physical_size) * UNIT_REGISTRY("millimeter")
+        return None
+
+
+class DicomReader(AbstractReader):
+    def read_thumb(self, out_width, out_height, precomputed=None, c=None, z=None, t=None):
+        pass
+
+    def read_window(self, region, out_width, out_height, c=None, z=None, t=None):
+        pass
+
+    def read_tile(self, tile, c=None, z=None, t=None):
+        pass
+
+
+class DicomFormat(AbstractFormat):
+    """Dicom Format.
+
+    References
+
+    """
+    checker_class = DicomChecker
+    parser_class = DicomParser
+    reader_class = DicomReader
+    histogram_reader_class = VipsHistogramReader  # TODO
+    convertor_class = VipsSpatialConvertor  # TODO
+
+    def __init__(self, *args, **kwargs):
+        super(DicomFormat, self).__init__(*args, **kwargs)
+        self._enabled = True
+
+    @classmethod
+    def is_spatial(cls):
+        return True
+
+    @cached_property
+    def need_conversion(self):
+        imd = self.main_imd
+        return not (imd.width < 1024 and imd.height < 1024)  # TODO
+
+    @property
+    def media_type(self):
+        return "application/dicom"

--- a/pims/formats/utils/abstract.py
+++ b/pims/formats/utils/abstract.py
@@ -104,6 +104,9 @@ class AbstractParser(ABC):
         pi = PlanesInfo(imd.n_channels, imd.depth, imd.duration)
         return pi
 
+    def parse_annotations(self):
+        return []
+
 
 class AbstractReader(ABC):
     def __init__(self, format):
@@ -361,3 +364,7 @@ class AbstractFormat(ABC, CachedData):
     @cached_property
     def main_path(self):
         return self.path
+
+    @cached_property
+    def annotations(self):
+        return self.parser.parse_annotations()

--- a/pims/formats/utils/abstract.py
+++ b/pims/formats/utils/abstract.py
@@ -128,11 +128,11 @@ class AbstractHistogramReader(HistogramReaderInterface, ABC):
 
 
 class NullHistogramReader(AbstractHistogramReader):
-    @abstractmethod
+    # @abstractmethod
     def type(self) -> HistogramType:
         return HistogramType.FAST
 
-    @abstractmethod
+    # @abstractmethod
     def image_bounds(self):
         log.warning(
             f"[orange]Impossible {self.format.path} to compute "
@@ -140,11 +140,11 @@ class NullHistogramReader(AbstractHistogramReader):
         )
         return 0, 2 ** self.format.main_imd.significant_bits
 
-    @abstractmethod
+    # @abstractmethod
     def image_histogram(self):
         raise BadRequestException(detail=f"No histogram found for {self.format.path}")
 
-    @abstractmethod
+    # @abstractmethod
     def channels_bounds(self):
         log.warning(
             f"[orange]Impossible {self.format.path} to compute "
@@ -152,7 +152,7 @@ class NullHistogramReader(AbstractHistogramReader):
         )
         return [(0, 2 ** self.format.main_imd.significant_bits)] * self.format.main_imd.n_channels
 
-    @abstractmethod
+    # @abstractmethod
     def channel_bounds(self, c):
         log.warning(
             f"[orange]Impossible {self.format.path} to compute "
@@ -160,11 +160,11 @@ class NullHistogramReader(AbstractHistogramReader):
         )
         return 0, 2 ** self.format.main_imd.significant_bits
 
-    @abstractmethod
+    # @abstractmethod
     def channel_histogram(self, c):
         raise BadRequestException(detail=f"No histogram found for {self.format.path}")
 
-    @abstractmethod
+    # @abstractmethod
     def planes_bounds(self):
         log.warning(
             f"[orange]Impossible {self.format.path} to compute "
@@ -172,7 +172,7 @@ class NullHistogramReader(AbstractHistogramReader):
         )
         return [(0, 2 ** self.format.main_imd.significant_bits)] * self.format.main_imd.n_planes
 
-    @abstractmethod
+    # @abstractmethod
     def plane_bounds(self, c, z, t):
         log.warning(
             f"[orange]Impossible {self.format.path} to compute "
@@ -180,7 +180,7 @@ class NullHistogramReader(AbstractHistogramReader):
         )
         return 0, 2 ** self.format.main_imd.significant_bits
 
-    @abstractmethod
+    # @abstractmethod
     def plane_histogram(self, c, z, t):
         raise BadRequestException(detail=f"No histogram found for {self.format.path}")
 

--- a/pims/formats/utils/annotations.py
+++ b/pims/formats/utils/annotations.py
@@ -1,0 +1,48 @@
+#  * Copyright (c) 2020-2021. Authors: see NOTICE file.
+#  *
+#  * Licensed under the Apache License, Version 2.0 (the "License");
+#  * you may not use this file except in compliance with the License.
+#  * You may obtain a copy of the License at
+#  *
+#  *      http://www.apache.org/licenses/LICENSE-2.0
+#  *
+#  * Unless required by applicable law or agreed to in writing, software
+#  * distributed under the License is distributed on an "AS IS" BASIS,
+#  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  * See the License for the specific language governing permissions and
+#  * limitations under the License.
+
+from pims.api.utils.image_parameter import ensure_list
+
+class ParsedMetadataAnnotation:
+    def __init__(self, geometry, c, z, t, terms=None, properties=None):
+        self.geometry = geometry
+
+        self.channels = ensure_list(c)
+        self.z_slices = ensure_list(z)
+        self.timepoints = ensure_list(t)
+
+        if terms is None:
+            terms = []
+        self.terms = terms
+
+        if properties is None:
+            properties = dict()
+        self.properties = properties
+
+    @property
+    def wkt(self):
+        return self.geometry.wkt
+
+    def add_term(self, term):
+        if term not in self.terms:
+            self.terms.append(term)
+
+    def add_property(self, key, value):
+        if key not in self.properties.keys():
+            self.properties[key] = value
+        else:
+            i = 1
+            while f"{key}.{i}" in self.properties.keys():
+                i = i+1
+            self.properties[f"{key}.{i}"] = value

--- a/pims/importer/listeners.py
+++ b/pims/importer/listeners.py
@@ -426,7 +426,7 @@ class CytomineListener(ImportListener):
             color = None
             if set_channel_names:
                 name = image.channels[c].suggested_name
-                color = image.channels[c].color
+                color = image.channels[c].hex_color
             for z in range(image.depth):
                 for t in range(image.duration):
                     mime = "image/pyrtiff"  # TODO: remove

--- a/pims/processing/utils.py
+++ b/pims/processing/utils.py
@@ -1,16 +1,19 @@
-# * Copyright (c) 2020. Authors: see NOTICE file.
-# *
-# * Licensed under the Apache License, Version 2.0 (the "License");
-# * you may not use this file except in compliance with the License.
-# * You may obtain a copy of the License at
-# *
-# *      http://www.apache.org/licenses/LICENSE-2.0
-# *
-# * Unless required by applicable law or agreed to in writing, software
-# * distributed under the License is distributed on an "AS IS" BASIS,
-# * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# * See the License for the specific language governing permissions and
-# * limitations under the License.
+#  * Copyright (c) 2020-2021. Authors: see NOTICE file.
+#  *
+#  * Licensed under the Apache License, Version 2.0 (the "License");
+#  * you may not use this file except in compliance with the License.
+#  * You may obtain a copy of the License at
+#  *
+#  *      http://www.apache.org/licenses/LICENSE-2.0
+#  *
+#  * Unless required by applicable law or agreed to in writing, software
+#  * distributed under the License is distributed on an "AS IS" BASIS,
+#  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  * See the License for the specific language governing permissions and
+#  * limitations under the License.
+import numpy as np
+from skimage import dtype_limits
+from skimage.exposure.exposure import _offset_array
 
 
 def find_first_available_int(values, mini=0, maxi=100):
@@ -47,3 +50,10 @@ def split_tuple(tuple_, index):
         return tuple_[index]
     else:
         return tuple_
+
+
+def to_unsigned_int(arr):
+    if arr.dtype is not np.uint8 or arr.dtype is not np.uint16:
+        arr_min, arr_max = dtype_limits(arr, clip_negative=False)
+        arr, _ = _offset_array(arr, arr_min, arr_max)
+    return arr

--- a/requirements.txt
+++ b/requirements.txt
@@ -161,6 +161,8 @@ python-dotenv==0.17.1
     # via
     #   pims (setup.py)
     #   uvicorn
+python-gdcm==3.0.10
+    # via pims (setup.py)
 python-multipart==0.0.5
     # via pims (setup.py)
 pytz==2021.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -144,6 +144,8 @@ pydantic==1.8.2
     # via
     #   fastapi
     #   pims (setup.py)
+pydicom==2.2.2
+    # via pims (setup.py)
 pygments==2.9.0
     # via rich
 pyparsing==2.4.7

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ REQUIRED = [
     'scikit-image>=0.18',
     'zarr>=2.8.3',
     'pydicom>=2.2.2',
+    'python-gdcm>=3.0.10',
 
     'Shapely>=1.8a1',
     'rasterio>=1.2.1',

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ REQUIRED = [
     'imagecodecs>=2021.3.31',
     'scikit-image>=0.18',
     'zarr>=2.8.3',
+    'pydicom>=2.2.2',
 
     'Shapely>=1.8a1',
     'rasterio>=1.2.1',


### PR DESCRIPTION
This PR adds support for DICOM images that were already supported by Cytomine-IMS. It closes #12.

Main current limitations are:
1. Sequence metadata tags are not parsed and some other tags could not be parsed correctly
2. Internal color manipulation is ignored (such as lut, some photometric interpretations, windowing etc)
2. 3D images cannot be converted to a faster visualisation format if needed
3. No support for WG26 extension thus not ready for whole-slide images ( e.g.no tiling, no pyramid support)