### PR TITLE
Add threshold processing parameter

### DIFF
--- a/pims/api/annotation.py
+++ b/pims/api/annotation.py
@@ -162,7 +162,7 @@ async def _show_crop(
     background_transparency,
     height, width, length, zoom, level,
     channels, z_slices, timepoints,
-    min_intensities, max_intensities, filters, gammas,
+    min_intensities, max_intensities, filters, gammas, threshold,
     bits, colorspace,
     extension, headers, config,
     colormaps=None, c_reduction=ChannelReduction.ADD, z_reduction=None, t_reduction=None,
@@ -190,7 +190,7 @@ async def _show_crop(
         height, width, length, zoom, level,
         channels, z_slices, timepoints,
         min_intensities, max_intensities,
-        filters, gammas, bits, colorspace,
+        filters, gammas, threshold, bits, colorspace,
         annots, annot_style,
         extension, headers, config,
         colormaps, c_reduction, z_reduction, t_reduction
@@ -232,7 +232,7 @@ async def _show_drawing(
     try_square, point_cross, point_envelope_length,
     height, width, length, zoom, level,
     channels, z_slices, timepoints,
-    min_intensities, max_intensities, filters, gammas, log,
+    min_intensities, max_intensities, filters, gammas, threshold, log,
     extension, headers, config,
     colormaps=None, c_reduction=ChannelReduction.ADD, z_reduction=None, t_reduction=None,
 ):
@@ -261,7 +261,7 @@ async def _show_drawing(
         height, width, length, zoom, level,
         channels, z_slices, timepoints,
         min_intensities, max_intensities,
-        filters, gammas, 8, Colorspace.AUTO,
+        filters, gammas, threshold, 8, Colorspace.AUTO,
         annots, annot_style,
         extension, headers, config,
         colormaps, c_reduction, z_reduction, t_reduction

--- a/pims/api/resized.py
+++ b/pims/api/resized.py
@@ -123,7 +123,7 @@ def _show_resized(
     path: Path,
     height, width, length, zoom, level,
     channels, z_slices, timepoints,
-    min_intensities, max_intensities, filters, gammas,
+    min_intensities, max_intensities, filters, gammas, threshold,
     bits, colorspace,
     extension,
     headers,
@@ -179,7 +179,7 @@ def _show_resized(
         out_format, out_width, out_height,
         c_reduction, z_reduction, t_reduction,
         gammas, filters, colormaps, min_intensities, max_intensities,
-        False, out_bitdepth, colorspace
+        False, out_bitdepth, threshold, colorspace
     ).http_response(
         mimetype,
         extra_headers=add_image_size_limit_header(dict(), *req_size, *out_size)

--- a/pims/api/thumb.py
+++ b/pims/api/thumb.py
@@ -114,7 +114,7 @@ def _show_thumb(
     path: Path,
     height, width, length,
     channels, z_slices, timepoints,
-    min_intensities, max_intensities, filters, gammas,
+    min_intensities, max_intensities, filters, gammas, threshold,
     log, use_precomputed,
     extension,
     headers,
@@ -166,7 +166,7 @@ def _show_thumb(
         out_format, out_width, out_height,
         c_reduction, z_reduction, t_reduction,
         gammas, filters, colormaps, min_intensities, max_intensities,
-        log, use_precomputed
+        log, use_precomputed, threshold
     ).http_response(
         mimetype,
         extra_headers=add_image_size_limit_header(dict(), *req_size, *out_size)

--- a/pims/api/tile.py
+++ b/pims/api/tile.py
@@ -118,7 +118,7 @@ def _show_tile(
     normalized: bool,
     tile: dict,
     channels, z_slices, timepoints,
-    min_intensities, max_intensities, filters, gammas, log,
+    min_intensities, max_intensities, filters, gammas, threshold, log,
     extension, headers, config,
     colormaps=None, c_reduction=ChannelReduction.ADD, z_reduction=None, t_reduction=None
 ):
@@ -199,14 +199,15 @@ def _show_tile(
             tile_region, out_format, out_width, out_height,
             c_reduction, z_reduction, t_reduction,
             gammas, filters, colormaps, min_intensities, max_intensities, log,
-            8, Colorspace.AUTO
+            8, threshold, Colorspace.AUTO
         )
     else:
         tile = TileResponse(
             in_image, channels, z_slices, timepoints,
             tile_region, out_format, out_width, out_height,
             c_reduction, z_reduction, t_reduction,
-            gammas, filters, colormaps, min_intensities, max_intensities, log
+            gammas, filters, colormaps, min_intensities, max_intensities, log,
+            threshold
         )
 
     return tile.http_response(

--- a/pims/api/utils/models.py
+++ b/pims/api/utils/models.py
@@ -105,6 +105,17 @@ class GammaList(BaseModel):
     __root__: Union[Gamma, List[Gamma]]
 
 
+class Threshold(BaseModel):
+    """
+    Threshold an image so that pixel intensities in the
+    original image below the threshold (scaled to pixel type)
+    are set to 0. If the target content type is an image
+    format supporting transparency, pixel intensities below
+    the threshold are transparent.
+    """
+    __root__: Optional[confloat(ge=0.0, le=1.0)]
+
+
 class FilterId(BaseModel):
     """
     A unique case-insensitive identifier for an image filter
@@ -191,6 +202,7 @@ class ImageIn(BaseModel):
     colormaps: Optional[ColormapIdList] = ColormapEnum.DEFAULT
     filters: Optional[FilterIdList] = None
     gammas: GammaList = 1.0
+    threshold: Threshold = None
 
     class Config:
         __mi_doc = "Intensity in the original image used as minimum intensity (black) to create the response." \
@@ -281,6 +293,7 @@ class ImageOpsDisplayQueryParams(BaseDependency):
     def __init__(
         self,
         gammas: Optional[List[confloat(ge=0.0, le=10.0)]] = Query([1.0]),
+        threshold: Optional[confloat(ge=0.0, le=1.0)] = Query(None),
         min_intensities: Optional[List[Union[IntensitySelectionEnum, conint(ge=0)]]] = Query(
             [
                 IntensitySelectionEnum.AUTO_IMAGE]
@@ -294,6 +307,7 @@ class ImageOpsDisplayQueryParams(BaseDependency):
         log: bool = Query(False),
     ):
         self.gammas = gammas
+        self.threshold = threshold
         self.min_intensities = min_intensities
         self.max_intensities = max_intensities
         self.colormaps = colormaps
@@ -357,6 +371,7 @@ class ImageOpsProcessingQueryParams(BaseDependency):
     def __init__(
         self,
         gammas: Optional[List[confloat(ge=0.0, le=10.0)]] = Query([1.0]),
+        threshold: Optional[confloat(ge=0.0, le=1.0)] = Query(None),
         min_intensities: Optional[List[Union[IntensitySelectionEnum, conint(ge=0)]]] = Query(None),
         max_intensities: Optional[List[Union[IntensitySelectionEnum, conint(ge=0)]]] = Query(None),
         colormaps: Optional[List[Union[str, ColormapEnum]]] = Query([ColormapEnum.DEFAULT]),
@@ -365,6 +380,7 @@ class ImageOpsProcessingQueryParams(BaseDependency):
         colorspace: Optional[Colorspace] = Query(Colorspace.AUTO)
     ):
         self.gammas = gammas
+        self.threshold = threshold
         self.min_intensities = min_intensities
         self.max_intensities = max_intensities
         self.colormaps = colormaps

--- a/pims/api/window.py
+++ b/pims/api/window.py
@@ -96,7 +96,7 @@ def _show_window(
     region: Union[Region, dict],
     height, width, length, zoom, level,
     channels, z_slices, timepoints,
-    min_intensities, max_intensities, filters, gammas,
+    min_intensities, max_intensities, filters, gammas, threshold,
     bits, colorspace,
     annotations: Union[ParsedAnnotations, dict, List[dict]],
     annotation_style: dict,
@@ -221,7 +221,7 @@ def _show_window(
             c_reduction, z_reduction, t_reduction,
             gammas, filters, colormaps,
             min_intensities, max_intensities, False,
-            out_bitdepth, colorspace,
+            out_bitdepth, threshold, colorspace,
             annotations, affine, annotation_style
         )
 

--- a/pims/processing/colormaps.py
+++ b/pims/processing/colormaps.py
@@ -144,6 +144,7 @@ class MatplotlibColormap(Colormap):
             lut[0, :] = 0
 
         lut *= (2 ** bitdepth - 1)
+        lut = np.rint(lut)
         return lut.astype(np_dtype(bitdepth))
 
 
@@ -184,6 +185,7 @@ class ColorColormap(Colormap):
             lut[0, :] = 0
 
         lut = lut * (2 ** bitdepth - 1)
+        lut = np.rint(lut)
         return lut.astype(np_dtype(bitdepth))
 
 
@@ -192,9 +194,9 @@ def default_lut(
     force_black_as_first: Optional[bool] = False  # Ignored but here for compat
 ) -> LookUpTable:
     """Default LUT"""
-    return np.stack(
+    return np.rint(np.stack(
         (np.arange(size),) * n_components, axis=-1
-    ).astype(np_dtype(bitdepth))
+    )).astype(np_dtype(bitdepth))
 
 
 def combine_lut(lut_a: LookUpTable, lut_b: LookUpTable) -> LookUpTable:

--- a/pims/processing/colormaps.py
+++ b/pims/processing/colormaps.py
@@ -115,7 +115,9 @@ class MatplotlibColormap(Colormap):
 
     def _init_cmap(self, size: int):
         # (Matplotlib already precomputes with N=256)
-        mpl_size = size if size != 256 else None
+        mpl_size = None
+        if size != 256 or self.ctype == ColormapType.QUALITATIVE:
+            mpl_size = size
         mpl_name = self.id + ("_r" if self.inverted else "")
         self._mpl_cmap[size] = get_cmap(mpl_name, mpl_size)
         self._mpl_cmap[size]._init()  # noqa
@@ -249,7 +251,7 @@ mpl_cmaps[ColormapType.DIVERGING] = [
     'RdYlBu', 'RdYlGn', 'Spectral', 'coolwarm', 'bwr', 'seismic']
 mpl_cmaps[ColormapType.CYCLIC] = [
     'twilight', 'twilight_shifted', 'hsv']
-mpl_cmaps[ColormapType.DIVERGING] = [
+mpl_cmaps[ColormapType.QUALITATIVE] = [
     'Pastel1', 'Pastel2', 'Paired', 'Accent',
     'Dark2', 'Set1', 'Set2', 'Set3',
     'tab10', 'tab20', 'tab20b', 'tab20c']

--- a/pims/processing/colormaps.py
+++ b/pims/processing/colormaps.py
@@ -132,7 +132,7 @@ class MatplotlibColormap(Colormap):
         if size not in self._mpl_cmap:
             self._init_cmap(size)
 
-        lut = self._mpl_cmap[size]._lut[:size, :n_components]  # noqa
+        lut = self._mpl_cmap[size]._lut[:size, :n_components].copy()  # noqa
         lut *= (2 ** bitdepth - 1)
         return lut.astype(np_dtype(bitdepth))
 

--- a/pims/processing/colormaps.py
+++ b/pims/processing/colormaps.py
@@ -17,7 +17,8 @@ from enum import Enum
 from typing import Dict, List, Optional, Union
 
 import numpy as np
-from matplotlib.cm import get_cmap
+from matplotlib.cm import get_cmap, register_cmap
+from matplotlib.colors import LinearSegmentedColormap as MplLinearSegmentedColormap
 from pydantic.color import COLORS_BY_NAME
 
 from pims.utils.color import Color
@@ -275,6 +276,23 @@ mpl_cmaps[ColormapType.MISCELLANEOUS] = [
     'gist_rainbow', 'rainbow', 'jet', 'turbo', 'nipy_spectral',
     'gist_ncar']
 
+# Custom colormaps
+_heatmap_data = (
+    (0.0, 0.0, 1.0),
+    (0.0, 1.0, 1.0),
+    (0.0, 1.0, 0.0),
+    (1.0, 1.0, 0.0),
+    (1.0, 0.0, 0.0)
+)
+_custom_cmaps = [
+    (MplLinearSegmentedColormap.from_list("heatmap", _heatmap_data),
+     ColormapType.SEQUENTIAL)
+]
+for custom_cmap in _custom_cmaps:
+    mpl, ctype = custom_cmap
+    register_cmap(None, mpl)
+    register_cmap(None, mpl.reversed())
+    mpl_cmaps[ctype].append(mpl.name)
 ColormapsByName = Dict[str, Colormap]
 
 # Non-trivial colormaps

--- a/pims/processing/image_response.py
+++ b/pims/processing/image_response.py
@@ -240,6 +240,7 @@ class ProcessedView(MultidimImageResponse, ABC):
             lut[lut < self.threshold] = 0.0
 
         lut *= self.max_intensity
+        lut = np.rint(lut)
         return lut.astype(np_dtype(self.best_effort_bitdepth))
 
     @property

--- a/pims/processing/image_response.py
+++ b/pims/processing/image_response.py
@@ -25,7 +25,7 @@ from pims.api.utils.models import (
 )
 from pims.files.image import Image
 from pims.filters import AbstractFilter
-from pims.processing.adapters import ImagePixels
+from pims.processing.adapters import ImagePixels, convert_to
 from pims.processing.annotations import ParsedAnnotations
 from pims.processing.colormaps import (
     Colormap, StackedLookUpTables, combine_stacked_lut, default_lut,
@@ -151,7 +151,7 @@ class ProcessedView(MultidimImageResponse, ABC):
         z_reduction: GenericReduction, t_reduction: GenericReduction,
         gammas: List[float], filters: List[Type[AbstractFilter]],
         colormaps: List[Colormap], min_intensities: List[int],
-        max_intensities: List[int], log: bool,
+        max_intensities: List[int], log: bool, threshold: Optional[float],
         colorspace: Colorspace = Colorspace.AUTO, **kwargs
     ):
         super().__init__(
@@ -166,12 +166,18 @@ class ProcessedView(MultidimImageResponse, ABC):
         self.min_intensities = min_intensities
         self.max_intensities = max_intensities
         self.log = log
+        self.threshold = threshold
         self.colorspace = colorspace
 
     @property
     def gamma_processing(self) -> bool:
         """Whether gamma processing is required"""
         return any(gamma != 1.0 for gamma in self.gammas)
+
+    @property
+    def threshold_processing(self) -> bool:
+        """Whether threshold processing is required"""
+        return self.threshold is not None and self.threshold > 0.0
 
     @property
     def log_processing(self) -> bool:
@@ -189,6 +195,7 @@ class ProcessedView(MultidimImageResponse, ABC):
         """Whether math lookup table has to be computed."""
         return (self.intensity_processing or
                 self.gamma_processing or
+                self.threshold_processing or
                 self.log_processing)
 
     @lru_cache(maxsize=None)
@@ -229,6 +236,9 @@ class ProcessedView(MultidimImageResponse, ABC):
             # (http://icy.bioimageanalysis.org/plugin/logarithmic-2d-viewer/)
             lut = np.log1p(lut) * 1. / np.log1p(1)
 
+        if self.threshold_processing:
+            lut[lut < self.threshold] = 0.0
+
         lut *= self.max_intensity
         return lut.astype(np_dtype(self.best_effort_bitdepth))
 
@@ -259,11 +269,13 @@ class ProcessedView(MultidimImageResponse, ABC):
                 colormap.lut(
                     size=self.max_intensity + 1,
                     bitdepth=self.best_effort_bitdepth,
-                    n_components=n_components
+                    n_components=n_components,
+                    force_black_as_first=self.threshold_processing
                 ) if colormap else default_lut(
                     size=self.max_intensity + 1,
                     bitdepth=self.best_effort_bitdepth,
-                    n_components=n_components
+                    n_components=n_components,
+                    force_black_as_first=self.threshold_processing
                 ) for colormap in self.colormaps
             ]
         )
@@ -432,6 +444,12 @@ class ProcessedView(MultidimImageResponse, ABC):
 
         if self.colorspace_processing:
             img = ColorspaceImgOp(self.new_colorspace)(img)
+
+        if self.threshold_processing:
+            img = TransparencyMaskImgOp(
+                100, convert_to(img, np.ndarray), self.out_bitdepth
+            )(img)
+
         return img
 
     def process_histogram(self) -> np.ndarray:
@@ -460,13 +478,13 @@ class ThumbnailResponse(ProcessedView):
         t_reduction: GenericReduction, gammas: List[float],
         filters: List[Type[AbstractFilter]], colormaps: List[Colormap],
         min_intensities: List[int], max_intensities: List[int], log: bool,
-        use_precomputed: bool, **kwargs
+        use_precomputed: bool, threshold: Optional[float], **kwargs
     ):
         super().__init__(
             in_image, in_channels, in_z_slices, in_timepoints, out_format,
             out_width, out_height, 8, c_reduction, z_reduction, t_reduction,
             gammas, filters, colormaps, min_intensities, max_intensities, log,
-            **kwargs
+            threshold, **kwargs
         )
 
         self.use_precomputed = use_precomputed
@@ -487,13 +505,13 @@ class ResizedResponse(ProcessedView):
         gammas: List[float], filters: List[Type[AbstractFilter]],
         colormaps: List[Colormap], min_intensities: List[int],
         max_intensities: List[int], log: bool, out_bitdepth: int,
-        colorspace: Colorspace, **kwargs
+        threshold: Optional[float], colorspace: Colorspace, **kwargs
     ):
         super().__init__(
             in_image, in_channels, in_z_slices, in_timepoints, out_format,
             out_width, out_height, out_bitdepth, c_reduction, z_reduction,
             t_reduction, gammas, filters, colormaps, min_intensities,
-            max_intensities, log, colorspace, **kwargs
+            max_intensities, log, threshold, colorspace, **kwargs
         )
 
     def raw_view(self, c: int, z: int, t: int) -> ImagePixels:
@@ -511,7 +529,8 @@ class WindowResponse(ProcessedView):
         gammas: List[float], filters: List[Type[AbstractFilter]],
         colormaps: List[Colormap], min_intensities: List[int],
         max_intensities: List[int], log: bool, out_bitdepth: int,
-        colorspace: Colorspace, annotations: Optional[ParsedAnnotations] = None,
+        threshold: Optional[float], colorspace: Colorspace,
+        annotations: Optional[ParsedAnnotations] = None,
         affine_matrix: Optional[np.ndarray] = None,
         annot_params: Optional[dict] = None, **kwargs
     ):
@@ -519,7 +538,7 @@ class WindowResponse(ProcessedView):
             in_image, in_channels, in_z_slices, in_timepoints, out_format,
             out_width, out_height, out_bitdepth, c_reduction, z_reduction,
             t_reduction, gammas, filters, colormaps, min_intensities,
-            max_intensities, log, colorspace, **kwargs
+            max_intensities, log, threshold, colorspace, **kwargs
         )
 
         self.region = region
@@ -586,13 +605,14 @@ class TileResponse(ProcessedView):
         z_reduction: GenericReduction, t_reduction: GenericReduction,
         gammas: List[float], filters: List[Type[AbstractFilter]],
         colormaps: List[Colormap], min_intensities: List[int],
-        max_intensities: List[int], log: bool, **kwargs
+        max_intensities: List[int], log: bool, threshold: Optional[float],
+        **kwargs
     ):
         super().__init__(
             in_image, in_channels, in_z_slices, in_timepoints, out_format,
             out_width, out_height, 8, c_reduction, z_reduction, t_reduction,
             gammas, filters, colormaps, min_intensities, max_intensities,
-            log, **kwargs
+            log, threshold, **kwargs
         )
 
         # Tile (region)

--- a/pims/processing/operations.py
+++ b/pims/processing/operations.py
@@ -310,7 +310,10 @@ class TransparencyMaskImgOp(ImageOp):
 
     def processed_mask(self, dtype: np.dtype) -> np.ndarray:
         mi = max_intensity(self.bitdepth)
-        mask = self.mask.astype(dtype)
+        mask = self.mask
+        if mask.ndim == 3:
+            mask = mask[:, :, 0]
+        mask = mask.astype(dtype)
         mask[mask > 0] = 1 * mi
         mask[mask == 0] = (1 - self.bg_transparency / 100) * mi
         return mask


### PR DESCRIPTION
Add a `threshold` parameter in image requests (thumb, resized, window, tile, annotations) to threshold an image so that pixel intensities in the original image below the threshold (scaled to pixel type) are set to 0. If the target content type is an image format supporting transparency, pixel intensities below the threshold are transparent.

Associated to an appropriate colormap, this `threshold` is well-suited to be used in a context of generating on-the-fly thresholded heatmaps.