### PR TITLE
Read virtual stack

### DIFF
--- a/pims/__version__.py
+++ b/pims/__version__.py
@@ -16,7 +16,7 @@
 
 # KEEP ENCODING - so that __version__ can be read even if py2.7 is used.
 
-VERSION = (0, 9, 3)
+VERSION = (0, 10, 2)
 API_VERSION = (0, 9, 0)
 
 __title__ = 'pims'

--- a/pims/api/formats.py
+++ b/pims/api/formats.py
@@ -44,6 +44,11 @@ class Format(BaseModel):
     writable: bool = Field(
         False, description='Whether PIMS can write a file in this format or not.'
     )
+    importable: bool = Field(
+        ...,
+        description='Whether the format is importable by an upload in PIMS or not. '
+                    'Non importable formats should be created by other means.'
+    )
     plugin: Optional[str] = Field(
         None,
         description='PIMS plugin providing this format, returned as a Python module.',
@@ -63,6 +68,7 @@ def _serialize_format(format):
         readable=format.is_readable(),
         writable=format.is_writable(),
         convertible=format.is_convertible(),
+        importable=format.is_importable(),
         plugin=format.get_plugin_name()
     )
 

--- a/pims/formats/common/virtual.py
+++ b/pims/formats/common/virtual.py
@@ -216,3 +216,13 @@ class VirtualStackFormat(AbstractFormat):
     @cached_property
     def need_conversion(self):
         return False
+
+    @classmethod
+    def is_importable(cls) -> bool:
+        # We do not allow to import virtual stacks as we do for regular images !
+        # As virtual stacks make references to other uploads, virtual stacks could
+        # be used to get privileges on other uploads !!
+        # The virtual stack file (JSON) is expected to be created by other means
+        # than the regular import, and by a service who has enough rights and is
+        # security-aware of access rights on images.
+        return False

--- a/pims/formats/common/virtual.py
+++ b/pims/formats/common/virtual.py
@@ -1,0 +1,218 @@
+#  * Copyright (c) 2020-2022. Authors: see NOTICE file.
+#  *
+#  * Licensed under the Apache License, Version 2.0 (the "License");
+#  * you may not use this file except in compliance with the License.
+#  * You may obtain a copy of the License at
+#  *
+#  *      http://www.apache.org/licenses/LICENSE-2.0
+#  *
+#  * Unless required by applicable law or agreed to in writing, software
+#  * distributed under the License is distributed on an "AS IS" BASIS,
+#  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  * See the License for the specific language governing permissions and
+#  * limitations under the License.
+import logging
+from functools import cached_property
+from typing import List, Optional, Union
+
+import numpy as np
+import orjson
+
+from pims.api.exceptions import MetadataParsingProblem
+from pims.config import get_settings
+from pims.formats import AbstractFormat
+from pims.formats.utils.abstract import CachedDataPath
+from pims.formats.utils.checker import SignatureChecker
+from pims.formats.utils.engines.vips import (
+    VipsSpatialConvertor
+)
+from pims.formats.utils.histogram import DefaultHistogramReader
+from pims.formats.utils.parser import AbstractParser
+from pims.formats.utils.reader import AbstractReader
+from pims.formats.utils.structures.metadata import ImageChannel, ImageMetadata, MetadataStore
+from pims.formats.utils.structures.planes import PlanesInfo
+from pims.formats.utils.structures.pyramid import Pyramid
+from pims.processing.adapters import RawImagePixels
+from pims.processing.region import Region, Tile
+from pims.utils.dtypes import dtype_to_bits
+from pims.utils.iterables import ensure_list
+from pims.utils.types import parse_datetime
+from pims.utils.vips import bandjoin, fix_rgb_interpretation
+
+log = logging.getLogger("pims.formats")
+
+
+def _json_load(path):
+    with open(path, "rb") as f:
+        return orjson.loads(f.read())
+
+
+def cached_json(format: Union[AbstractFormat, CachedDataPath]) -> dict:
+    return format.get_cached(
+        '_json', _json_load, str(format.path.resolve())
+    )
+
+
+class VirtualStackChecker(SignatureChecker):
+    @classmethod
+    def match(cls, pathlike: CachedDataPath) -> bool:
+        try:
+            json_data = cached_json(pathlike)
+            return json_data.get("schema") == "virtual/stack"
+        except ValueError:
+            return False
+
+
+class VirtualStackParser(AbstractParser):
+    def parse_main_metadata(self) -> ImageMetadata:
+        image = cached_json(self.format)
+        metadata = image.get("image")
+        if metadata is None:
+            raise MetadataParsingProblem(self.format.path)
+
+        imd = ImageMetadata()
+        imd.width = metadata.get("width")
+        imd.height = metadata.get("height")
+        imd.n_channels = metadata.get("n_channels")
+        imd.depth = metadata.get("depth")
+        imd.duration = metadata.get("duration")
+        imd.n_intrinsic_channels = metadata.get("n_channels")
+        imd.n_channels_per_read = 1
+
+        imd.pixel_type = np.dtype(metadata.get("pixel_type"))
+        imd.significant_bits = dtype_to_bits(imd.pixel_type)
+
+        for i, channel in enumerate(image.get("channels")):
+            imd.set_channel(
+                ImageChannel(index=i, color=channel.get("color"))
+            )
+
+        return imd
+
+    def parse_known_metadata(self) -> ImageMetadata:
+        imd = super().parse_known_metadata()
+
+        image = cached_json(self.format)
+        metadata = image.get("image")
+        if metadata is None:
+            raise MetadataParsingProblem(self.format.path)
+
+        imd.description = metadata.get("description")
+        imd.acquisition_datetime = parse_datetime(
+            metadata.get("acquired_at")
+        )
+
+        imd.physical_size_x = metadata.get("physical_size_x")
+        imd.physical_size_y = metadata.get("physical_size_y")
+        imd.physical_size_z = metadata.get("physical_size_z")
+        imd.frame_rate = metadata.get("frame_rate")
+
+        for parsed_channel, channel in zip(imd.channels, image.get("channels")):
+            parsed_channel.suggested_name = channel.get("suggested_name")
+            parsed_channel.emission_wavelength = channel.get("emission_wavelength")
+            parsed_channel.excitation_wavelength = channel.get("excitation_wavelength")
+
+        imd.is_complete = True
+        return imd
+
+    def parse_raw_metadata(self) -> MetadataStore:
+        store = super().parse_raw_metadata()
+        return store
+
+    def parse_pyramid(self) -> Pyramid:
+        return super().parse_pyramid()  # TODO
+
+    def parse_planes(self) -> PlanesInfo:
+        imd = self.format.main_imd
+        pi = PlanesInfo(
+            imd.n_intrinsic_channels, imd.depth, imd.duration,
+            ['location'], ['U255']
+        )
+
+        image = cached_json(self.format)
+        planes = image.get("planes")
+        for c in range(imd.n_intrinsic_channels):
+            for z in range(imd.depth):
+                for t in range(imd.duration):
+                    key = f"C{c}_Z{z}_T{t}"
+                    pi.set(c, z, t, location=planes[key]["location"])
+
+        return pi
+
+
+class VirtualStackReader(AbstractReader):
+    @staticmethod
+    def _get_underlying_format(filepath):
+        from pims.formats.utils.factories import SpatialReadableFormatFactory
+        from pims.files.file import Path
+        FILE_ROOT_PATH = get_settings().root
+        return SpatialReadableFormatFactory(match_on_ext=True).match(
+            Path(FILE_ROOT_PATH, filepath).get_spatial()
+        )
+
+    def read_thumb(self, out_width: int, out_height: int, precomputed: bool = None,
+                   c: Optional[Union[int, List[int]]] = None, z: Optional[int] = None,
+                   t: Optional[int] = None) -> RawImagePixels:
+        bands = list()
+        if c is None:
+            channels = list(range(self.format.main_imd.n_channels))
+        else:
+            channels = ensure_list(c)
+
+        for c in channels:
+            bands.append(self._get_underlying_format(
+                self.format.planes_info.get(c, z, t, "location")
+            ).reader.read_thumb(out_width, out_height, precomputed))
+
+        im = bandjoin(bands)
+        if c == [0, 1, 2]:
+            im = fix_rgb_interpretation(im)
+        return im
+
+    def read_window(self, region: Region, out_width: int, out_height: int,
+                    c: Optional[Union[int, List[int]]] = None, z: Optional[int] = None,
+                    t: Optional[int] = None) -> RawImagePixels:
+        bands = list()
+        if c is None:
+            channels = list(range(self.format.main_imd.n_channels))
+        else:
+            channels = ensure_list(c)
+
+        for c in channels:
+            bands.append(self._get_underlying_format(
+                self.format.planes_info.get(c, z, t, "location")
+            ).reader.read_window(region, out_width, out_height))
+
+        im = bandjoin(bands)
+        if c == [0, 1, 2]:
+            im = fix_rgb_interpretation(im)
+        return im
+
+    def read_tile(self, tile: Tile, c: Optional[Union[int, List[int]]] = None,
+                  z: Optional[int] = None, t: Optional[int] = None) -> RawImagePixels:
+        return self.read_window(
+            tile, int(tile.width), int(tile.height), c, z, t
+        )
+
+
+class VirtualStackFormat(AbstractFormat):
+    """VirtualStack Format.
+
+    """
+    checker_class = VirtualStackChecker
+    parser_class = VirtualStackParser
+    reader_class = VirtualStackReader
+    histogram_reader_class = DefaultHistogramReader
+    convertor_class = VipsSpatialConvertor
+
+    def __init__(self, *args, **kwargs):
+        super(VirtualStackFormat, self).__init__(*args, **kwargs)
+        self._enabled = True
+
+    @classmethod
+    def is_spatial(cls):
+        return True
+
+    @cached_property
+    def need_conversion(self):
+        return False

--- a/pims/formats/utils/abstract.py
+++ b/pims/formats/utils/abstract.py
@@ -154,6 +154,11 @@ class AbstractFormat(ABC, SimpleDataCache):
         return cls.convertor_class is not None
 
     @classmethod
+    def is_importable(cls) -> bool:
+        """Whether PIMS allows to import images in this format."""
+        return True
+
+    @classmethod
     def is_spatial(cls) -> bool:
         """Whether this format is adapted for spatial data requests."""
         return False

--- a/pims/formats/utils/factories.py
+++ b/pims/formats/utils/factories.py
@@ -72,6 +72,16 @@ class FormatFactory:
         return None
 
 
+class ImportableFormatFactory(FormatFactory):
+    def __init__(self, match_on_ext: bool = False):
+        formats = {
+            e: f
+            for e, f in FORMATS.items()
+            if f.is_importable()
+        }
+        super(ImportableFormatFactory, self).__init__(match_on_ext, formats)
+
+
 class SpatialReadableFormatFactory(FormatFactory):
     def __init__(self, match_on_ext: bool = False):
         formats = {

--- a/pims/formats/utils/factories.py
+++ b/pims/formats/utils/factories.py
@@ -58,8 +58,11 @@ class FormatFactory:
             a match. None otherwise.
         """
         if self.match_on_ext:
-            format = self.formats.get(path.extension)
-            if format:
+            extension = path.extension
+            if len(extension) > 0:
+                extension = extension[1:]
+            format = self.formats.get(extension)
+            if format is not None:
                 return format(path)
         proxy = CachedDataPath(path)
         for format in self.formats.values():

--- a/pims/importer/importer.py
+++ b/pims/importer/importer.py
@@ -32,7 +32,10 @@ from pims.files.file import (
 from pims.files.histogram import Histogram
 from pims.files.image import Image
 from pims.formats import AbstractFormat
-from pims.formats.utils.factories import FormatFactory, SpatialReadableFormatFactory
+from pims.formats.utils.factories import (
+    ImportableFormatFactory,
+    SpatialReadableFormatFactory
+)
 from pims.importer.listeners import (
     CytomineListener, ImportEventType, ImportListener,
     StdoutListener
@@ -186,7 +189,7 @@ class FileImporter:
             # Identify format
             self.notify(ImportEventType.START_FORMAT_DETECTION, self.upload_path)
 
-            format_factory = FormatFactory()
+            format_factory = ImportableFormatFactory()
             format = format_factory.match(self.upload_path)
             archive = None
             if format is None:
@@ -427,7 +430,7 @@ class FileImporter:
             task = Task.IMPORT
 
         imported = list()
-        format_factory = FormatFactory()
+        format_factory = ImportableFormatFactory()
         tasks = list()
         # Collection children are extracted recursively into collection
         # directories, until the directory is an image format (we can thus have


### PR DESCRIPTION
This PR add support for virtual stacks. A virtual stack is stack of 2D images, organized to mimic up to a 5D (XYCZT) image. 

The stack is described by a JSON file whose specification are given in `VirtualStackFormat` docstring.

The images that are used to create the stack are expected to be images already imported. As a consequence, it is not allowed for a virtual stack (JSON file) to be importable as other regular image format, as it would introduce a large security breach. 

The virtual stack "upload" directory has to be created by other means like a service on top of PIMS who manages access rights on images (e.g. Cytomine-core), with a special PIMS endpoint. **This is not implemented yet**.

In short, the PR adds:
* the notion of *importable* format (virtual stack is currently the only format not regularly importable)
* the possibility to read virtual stacks whose the descriptor JSON file has been created by other means (currently: manually).